### PR TITLE
Fix stylus compile function and include nib by default

### DIFF
--- a/app/lib/middleware.js
+++ b/app/lib/middleware.js
@@ -1,6 +1,7 @@
 var express         = require('express'),
     connect         = require('connect'),
     stylus          = require('stylus'),
+    nib             = require('nib'),
     connect_timeout = require('connect-timeout'),
     MongoServer     = require('mongodb').Server,
     MongoStore      = require('connect-mongodb');
@@ -18,6 +19,8 @@ module.exports = function(app) {
       return stylus(str)
         .set('filename', path)
         .set('compress', true)
+        .use(nib())
+        .import('nib');
     },
     force: true
   });

--- a/package.json
+++ b/package.json
@@ -13,6 +13,8 @@
         "connect": "2.0.3",
         "connect-timeout": "latest",
         "stylus": "latest",
+        "nib": "latest",
+        "canvas": "latest",
         "mongodb": "latest",
         "connect-mongodb": "latest",
         "express-resource": "latest",


### PR DESCRIPTION
`compileMethod` seems to be a rather old method that is no longer in use.

Updated to `compile` method with appropriate args.

Additionally, including nib by default for css3 extensions and other lovely magic like `fixed top left` to generate

``` css
  position: fixed;
  top: 0;
  left: 0;
```
